### PR TITLE
Feat: Add GitLab CI configuration file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+stages:
+  - build
+  - release
+
+image: docker:latest
+
+services:
+  - docker:dind
+
+before_script:
+  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+
+build-master-branch-or-version-tagged-ref:
+  retry: 1
+  stage: build
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE" .
+    - docker push "$CI_REGISTRY_IMAGE"
+  only:
+    - master
+    - /^v(\d+\.)?(\d+\.)?(\*|\d+)$/
+
+release-version-tagged-ref:
+  retry: 1
+  stage: release
+  script:
+    - docker pull "$CI_REGISTRY_IMAGE:latest"
+    - docker tag "$CI_REGISTRY_IMAGE" "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - branches
+  only:
+    - /^v(\d+\.)?(\d+\.)?(\*|\d+)$/
+
+build-devel-branch:
+  retry: 1
+  stage: build
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - tags
+  only:
+    - devel
+
+build-feature-branch:
+  retry: 1
+  stage: build
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" .
+    - docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+  except:
+    - devel
+    - master
+    - tags
+  only:
+    - branches
+


### PR DESCRIPTION
A GitLab CI configuration file.

When a commit is pushed to the GitLab myMPD repository, a new container build will be triggered and the result will be pushed to the users private GitLab container registry.

The container images will be tagged with either:

1. 'latest' if the commit is on the branch: master
2. The committed git tag name, only if it matches the format used for versioning (eg v0.0.0)
3. 'devel' if the commit is on branch: devel
4. The branch name the commit was made against, if none of the criteria 1-3 are met.

The use case is mostly for those who wish to use the primary (jcorporation) repository as upstream, periodically fetch any updates and push them to their private GitLab repo.