### PR TITLE
Updated ebuild for gentoo linux

### DIFF
--- a/contrib/initscripts/mympd.openrc.in
+++ b/contrib/initscripts/mympd.openrc.in
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # myMPD (c) 2018-2020 Juergen Mang <mail@jcgames.de>
 # https://github.com/jcorporation/mympd
-#
-# myMPD open-rc file for alpine linux.
 
 name=mympd
 command="@CMAKE_INSTALL_FULL_BINDIR@/mympd"

--- a/contrib/packaging/gentoo/mympd-6.4.0.ebuild
+++ b/contrib/packaging/gentoo/mympd-6.4.0.ebuild
@@ -1,27 +1,31 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Copyright 2020 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
+EAPI=7
 
-EAPI=6
-
-inherit eutils user cmake-utils
+inherit eutils user cmake-utils systemd
 
 MY_PN="myMPD"
 
 DESCRIPTION="myMPD is a standalone and mobile friendly web mpdclient"
 HOMEPAGE="https://github.com/jcorporation/myMPD"
-SRC_URI="https://github.com/jcorporation/${MY_PN}/archive/v${PV}.tar.gz"
+SRC_URI="https://github.com/jcorporation/${MY_PN}/archive/v${PV}.tar.gz -> ${PN}-${PV}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~arm ~arm64"
-IUSE=""
+IUSE="+flac +id3tag +ssl +java systemd"
 
-DEPEND=""
-RDEPEND="${DEPEND}"
-BDEPEND=""
+BDEPEND="
+        dev-util/cmake
+        java? ( virtual/jre )
+        dev-lang/perl
+"
+RDEPEND="
+        media-sound/mpd[flac?,id3tag?]
+        ssl? ( dev-libs/openssl )
+        systemd? ( sys-apps/systemd )
+"
 
 S="${WORKDIR}/${MY_PN}-${PV}"
 
@@ -32,6 +36,9 @@ pkg_setup() {
 
 src_compile() {
     default
+    ENABLE_SSL=$(usex ssl "ON" "OFF")
+    ENABLE_LIBID3TAG=$(usex id3tag "ON" "OFF")
+    ENABLE_FLAC=$(usex flac "ON" "OFF")
     ./build.sh release
 }
 
@@ -39,7 +46,17 @@ src_install() {
     cd release
     dobin mympd
     dobin cli_tools/mympd-config
-    newinitd "${FILESDIR}/${PN}.init.d" "${PN}"
-    insinto /etc
-    newins "${FILESDIR}/${PN}.conf" "${PN}.conf"
+    newinitd "contrib/initscripts/mympd.openrc" "${PN}"
+    if use systemd; then
+        systemd_newunit contrib/initscripts/mympd.service mympd.service
+    fi
+    ${D}/usr/bin/mympd-config --mympdconf ${D}/etc/mympd.conf
+    dodoc ${S}/README.md
+}
+
+pkg_postinst() {
+    elog
+    elog "Adapt the configuration file /etc/mympd.conf to your needs or use the"
+    elog "\`mympd-config\` tool to generate automatically a valid mympd.conf"
+    elog
 }


### PR DESCRIPTION
Changes for mympd-6.4.0.ebuild:
Uses EAPI-7 (actual for now).
Defined dependencies.
Added use-flags.
Proper install open-rc initscript.
Install systemd unit (if needed).
Generating and installing mympd.conf.
Install doc file README.md
