### PR TITLE
Add OpenWrt package recipe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -94,8 +94,8 @@ setversion() {
   echo "Setting version to ${VERSION} and date to ${DATE_F2}"
 
   for F in htdocs/sw.js contrib/packaging/alpine/APKBUILD contrib/packaging/arch/PKGBUILD \
-  		   contrib/packaging/rpm/mympd.spec contrib/packaging/debian/changelog contrib/man/mympd.1 \
-  		   contrib/man/mympd-script.1
+  		   contrib/packaging/rpm/mympd.spec contrib/packaging/debian/changelog \
+  		   contrib/packaging/openwrt/Makefile contrib/man/mympd.1 contrib/man/mympd-script.1
   do
   	echo "$F"
   	sed -e "s/__VERSION__/${VERSION}/g" -e "s/__DATE_F1__/$DATE_F1/g" -e "s/__DATE_F2__/$DATE_F2/g" \
@@ -554,6 +554,35 @@ pkgarch() {
   fi
 }
 
+pkgopenwrt() {
+  echo "Building with SDK"
+  echo "1. Download desired version of OpenWrt SDK for Your device"
+  echo "   from: https://openwrt.org/downloads"
+  echo "   The SDK must match the version of OpenWrt istalled on Your device."
+  echo "2. Unpack SDK and change current directory to it."
+  echo "3. Run following commands to download dependencies recipes:"
+  echo "    scripts/feeds update -a"
+  echo "    scripts/feeds install libflac libid3tag liblua5.3 libopenssl libpcre"
+  echo "4. Copy contents of 'contrib/packaging/openwrt' from myMPD tree"
+  echo "   to 'package/mympd' directory of SDK."
+  echo "5. To build package run:"
+  echo "    make -j\$(nproc) BUILD_LOG=1"
+  echo "6. Resulting package will be placed in 'bin' directory."
+  echo
+  echo "Building in full OpenWrt buildroot"
+  echo "1. Clone the OpenWrt tree https://git.openwrt.org/openwrt/openwrt.git"
+  echo "2. Run following commands to download dependencies recipes:"
+  echo "    scripts/feeds update -a"
+  echo "    scripts/feeds install libflac libid3tag liblua5.3 libopenssl libpcre"
+  echo "3. Copy contents of 'contrib/packaging/openwrt' from myMPD tree"
+  echo "   to 'package/mympd' directory of SDK."
+  echo "4. To select myMPD package build run:"
+  echo "    make menuconfig"
+  echo "   and select it in 'Sound' menu, to build it run:"
+  echo "    make -j\$(nproc) BUILD_LOG=1"
+  echo "6. Resulting package will be placed in 'bin' directory."
+}
+
 pkgosc() {
   check_cmd osc
   cleanup
@@ -959,6 +988,9 @@ case "$ACTION" in
 	pkgarch)
 	  pkgarch
 	;;
+	pkgopenwrt)
+	  pkgopenwrt
+	;;
 	setversion)
 	  setversion
 	;;
@@ -1070,6 +1102,9 @@ case "$ACTION" in
       echo "                      - DOCKERFILE=\"Dockerfile.alpine\""
       echo "                      - PLATFORMS=\"linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6\""
 	  echo "  pkgrpm:           creates the rpm package"
+	  echo "  pkgopenwrt:       shows package build instructions, given the nature"
+	  echo "                    of OpenWrt (cross compilation), it's difficult to"
+	  echo "                    consider all options"
 	  echo "  pkgosc:           updates the open build service repository"
 	  echo "                    following environment variables are respected"
 	  echo "                      - OSC_REPO=\"home:jcorporation/myMPD\""

--- a/contrib/packaging/openwrt/Makefile
+++ b/contrib/packaging/openwrt/Makefile
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2021 Tomasz Maciej Nowak <tmn505@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME := mympd
+PKG_VERSION := 8.0.3
+PKG_RELEASE := 1
+
+PKG_SOURCE := $(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL := https://codeload.github.com/jcorporation/myMPD/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH := skip
+
+PKG_LICENSE := GPL-2.0
+PKG_LICENSE_FILE := LICENSE
+
+PKG_MAINTAINER := Juergen Mang <mail [at] jcgames [dot] de>
+
+PKG_BUILD_DIR := $(BUILD_DIR)/myMPD-$(PKG_VERSION)
+PKG_BUILD_PARALLEL := 1
+PKG_FORTIFY_SOURCE := 0
+PKG_CONFIG_DEPENDS := \
+	CONFIG_MYMPD_FLAC \
+	CONFIG_MYMPD_ID3TAG \
+	CONFIG_MYMPD_LUA \
+	CONFIG_MYMPD_SSL
+
+CMAKE_BINARY_SUBDIR := release
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mympd
+  SECTION := sound
+  CATEGORY := Sound
+  TITLE := myMPD - web MPD client and more
+  URL := https://jcorporation.github.io
+  DEPENDS := +libpcre +MYMPD_FLAC:libflac +MYMPD_ID3TAG:libid3tag +MYMPD_LUA:liblua5.3 +MYMPD_SSL:libopenssl
+  USERID := mympd:mympd
+endef
+
+define Package/mympd/description
+Standalone and mobile friendly web MPD client with a tiny footprint and advanced features.
+endef
+
+define Package/mympd/config
+	if PACKAGE_mympd
+
+		config MYMPD_FLAC
+			bool "Extracting cover images from FLAC files"
+			default y
+
+		config MYMPD_ID3TAG
+			bool "Extracting cover images from ID3 tags"
+			default y
+
+		config MYMPD_LUA
+			bool "LUA scripts support"
+			default n
+
+		config MYMPD_SSL
+			bool "HTTPS support (with OpenSSL)"
+			default n
+
+	endif
+endef
+
+CMAKE_OPTIONS += \
+	-DCMAKE_BUILD_TYPE=RELEASE \
+	-DENABLE_FLAC=$(if $(CONFIG_MYMPD_FLAC),ON,OFF) \
+	-DENABLE_LIBID3TAG=$(if $(CONFIG_MYMPD_ID3TAG),ON,OFF) \
+	-DENABLE_LUA=$(if $(CONFIG_MYMPD_LUA),ON,OFF) \
+	-DENABLE_SSL=$(if $(CONFIG_MYMPD_SSL),ON,OFF)
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	(cd $(PKG_BUILD_DIR); ./build.sh createassets)
+endef
+
+define Package/mympd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mympd $(1)/usr/bin/
+	$(if $(CONFIG_MYMPD_LUA),$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mympd-script $(1)/usr/bin/)
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/mympd.config $(1)/etc/config/mympd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mympd.init $(1)/etc/init.d/mympd
+endef
+
+$(eval $(call BuildPackage,mympd))

--- a/contrib/packaging/openwrt/Makefile.in
+++ b/contrib/packaging/openwrt/Makefile.in
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2021 Tomasz Maciej Nowak <tmn505@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME := mympd
+PKG_VERSION := __VERSION__
+PKG_RELEASE := 1
+
+PKG_SOURCE := $(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL := https://codeload.github.com/jcorporation/myMPD/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH := skip
+
+PKG_LICENSE := GPL-2.0
+PKG_LICENSE_FILE := LICENSE
+
+PKG_MAINTAINER := Juergen Mang <mail [at] jcgames [dot] de>
+
+PKG_BUILD_DIR := $(BUILD_DIR)/myMPD-$(PKG_VERSION)
+PKG_BUILD_PARALLEL := 1
+PKG_FORTIFY_SOURCE := 0
+PKG_CONFIG_DEPENDS := \
+	CONFIG_MYMPD_FLAC \
+	CONFIG_MYMPD_ID3TAG \
+	CONFIG_MYMPD_LUA \
+	CONFIG_MYMPD_SSL
+
+CMAKE_BINARY_SUBDIR := release
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/mympd
+  SECTION := sound
+  CATEGORY := Sound
+  TITLE := myMPD - web MPD client and more
+  URL := https://jcorporation.github.io
+  DEPENDS := +libpcre +MYMPD_FLAC:libflac +MYMPD_ID3TAG:libid3tag +MYMPD_LUA:liblua5.3 +MYMPD_SSL:libopenssl
+  USERID := mympd:mympd
+endef
+
+define Package/mympd/description
+Standalone and mobile friendly web MPD client with a tiny footprint and advanced features.
+endef
+
+define Package/mympd/config
+	if PACKAGE_mympd
+
+		config MYMPD_FLAC
+			bool "Extracting cover images from FLAC files"
+			default y
+
+		config MYMPD_ID3TAG
+			bool "Extracting cover images from ID3 tags"
+			default y
+
+		config MYMPD_LUA
+			bool "LUA scripts support"
+			default n
+
+		config MYMPD_SSL
+			bool "HTTPS support (with OpenSSL)"
+			default n
+
+	endif
+endef
+
+CMAKE_OPTIONS += \
+	-DCMAKE_BUILD_TYPE=RELEASE \
+	-DENABLE_FLAC=$(if $(CONFIG_MYMPD_FLAC),ON,OFF) \
+	-DENABLE_LIBID3TAG=$(if $(CONFIG_MYMPD_ID3TAG),ON,OFF) \
+	-DENABLE_LUA=$(if $(CONFIG_MYMPD_LUA),ON,OFF) \
+	-DENABLE_SSL=$(if $(CONFIG_MYMPD_SSL),ON,OFF)
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	(cd $(PKG_BUILD_DIR); ./build.sh createassets)
+endef
+
+define Package/mympd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mympd $(1)/usr/bin/
+	$(if $(CONFIG_MYMPD_LUA),$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mympd-script $(1)/usr/bin/)
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/mympd.config $(1)/etc/config/mympd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mympd.init $(1)/etc/init.d/mympd
+endef
+
+$(eval $(call BuildPackage,mympd))

--- a/contrib/packaging/openwrt/files/mympd.config
+++ b/contrib/packaging/openwrt/files/mympd.config
@@ -1,0 +1,23 @@
+# Consult documentation at https://jcorporation.github.io/myMPD/configuration
+config mympd main
+	# CAUTION: there can be a lot of writes to workdir directory
+	# and if it's on raw flash, this can kill it very fast.
+	option workdir '/var/lib/mympd'
+	option mpd_host 'localhost'
+	option mpd_port '6600'
+	option acl ''
+	option http_host '0.0.0.0'
+	option http_port '80'
+	option loglevel '5'
+
+	# Requires enabled MYMPD_LUA at compilation time
+	option lualibs 'all'
+	option scriptacl '+127.0.0.1'
+
+	# Requires enabled MYMPD_SSL at compilation time
+	option ssl 'false'
+	option ssl_port '443'
+	option ssl_san ''
+	option custom_cert 'false'
+	option ssl_cert ''
+	option ssl_key ''

--- a/contrib/packaging/openwrt/files/mympd.init
+++ b/contrib/packaging/openwrt/files/mympd.init
@@ -1,0 +1,49 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=94
+
+start_service() {
+	config_load /etc/config/mympd
+
+	local tempdir=$(mktemp -d)
+	local configdir=${tempdir}/config
+	local statedir=${tempdir}/state
+
+	mkdir -p -m 755 ${configdir} ${statedir}
+
+	[ -z "${mpd_host}" ] && mpd_host='localhost'
+	config_get main mpd_host > ${statedir}/mpd_host
+	[ -z "${mpd_port}" ] && mpd_port='6600'
+	config_get main mpd_port > ${statedir}/mpd_port
+
+	config_get main acl > ${configdir}/acl
+	config_get main http_host > ${configdir}/http_host
+	config_get main http_port > ${configdir}/http_port
+	config_get main loglevel > ${configdir}/loglevel
+
+	config_get main lualibs > ${configdir}/lualibs
+	config_get main scriptacl > ${configdir}/scriptacl
+
+	config_get main ssl > ${configdir}/ssl
+	config_get main ssl_port > ${configdir}/ssl_port
+	config_get main ssl_san > ${configdir}/ssl_san
+	config_get main custom_cert > ${configdir}/custom_cert
+	config_get main ssl_cert > ${configdir}/ssl_cert
+	config_get main ssl_key > ${configdir}/ssl_key
+
+	local workdir
+	config_get workdir main workdir
+	[ -z "${workdir}" ] && workdir='/var/lib/mympd'
+	mkdir -p -m 755 ${workdir}
+	cp -f -R ${tempdir}/* ${workdir}/
+	rm -f -R ${tempdir}
+	chown -R mympd:mympd ${workdir}
+
+	procd_open_instance mympd
+	procd_set_param file /etc/config/mympd
+	procd_set_param command /usr/bin/mympd -w ${workdir}
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance mympd
+}


### PR DESCRIPTION
By default LUA scripts and SSL are disabled, these can be enabled before building in menuconfig. Given the nature of OpenWrt, which needs particular toolchain for build, only typical instructions to build ipk package are added.
I'm fine if You want to drop the `pkgopenwrt` option with build instructions, those don't exhaust all possibilities where something could go wrong or could be adjusted.