### PR TITLE
incorrect libpcre2 package dependancy for Debian

### DIFF
--- a/contrib/packaging/debian/control
+++ b/contrib/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: https://jcorporation.github.io/myMPD/
 
 Package: mympd
 Architecture: any
-Depends: libc6, openssl, libid3tag0, libflac8, liblua5.3-0, libpcre2
+Depends: libc6, openssl, libid3tag0, libflac8, liblua5.3-0, libpcre2-posix2
 Description: Standalone and mobile friendly web-based MPD client.
  myMPD is a standalone and lightweight web-based MPD client. It's tuned for
  minimal resource usage and requires only very few dependencies.


### PR DESCRIPTION
myMPD version: 9.0.0

**Describe the bug**

Pre-compiled debian package for Bullseye depends on package `libpcre2`, which does not exist in Debian bullseye.
The nearest candidate seems to be `libpcre2-posix2`.

```
# dpkg -i mympd_9.0.0-1_amd64.deb
(Reading database ... 187723 files and directories currently installed.)
Preparing to unpack mympd_9.0.0-1_amd64.deb ...
Unpacking mympd (9.0.0-1) over (9.0.0-1) ...
dpkg: dependency problems prevent configuration of mympd:
 mympd depends on libpcre2; however:
  Package libpcre2 is not installed.

dpkg: error processing package mympd (--install):
 dependency problems - leaving unconfigured
Processing triggers for man-db (2.9.4-2) ...
Errors were encountered while processing:
 mympd

# apt-get install libpcre2
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package libpcre2 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libpcre2' has no installation candidate

# apt search libpcre2
Sorting... Done
Full Text Search... Done
libpcre2-16-0/stable,now 10.36-2 amd64 [installed,automatic]
  New Perl Compatible Regular Expression Library - 16 bit runtime files

libpcre2-32-0/stable,now 10.36-2 amd64 [installed,automatic]
  New Perl Compatible Regular Expression Library - 32 bit runtime files

libpcre2-8-0/stable,now 10.36-2 amd64 [installed,automatic]
  New Perl Compatible Regular Expression Library- 8 bit runtime files

libpcre2-dev/stable,now 10.36-2 amd64 [installed,automatic]
  New Perl Compatible Regular Expression Library - development files

libpcre2-posix2/stable,now 10.36-2 amd64 [installed,automatic]
  New Perl Compatible Regular Expression Library - posix-compatible runtime files

pcre2-utils/stable 10.36-2 amd64
  New Perl Compatible Regular Expression Library - utilities
```

modifiying the Depends line in `contrib/packaging/debian/control` with `Depends: libc6, openssl, libid3tag0, libflac8, liblua5.3-0, libpcre2-posix2` and recompiling using `./build.sh sbuild_build` fixes the problem.