### PR TITLE
gentoo ebuild: RDEPEND update

### DIFF
--- a/contrib/packaging/gentoo/media-sound/mympd/mympd-9.0.0.ebuild
+++ b/contrib/packaging/gentoo/media-sound/mympd/mympd-9.0.0.ebuild
@@ -28,7 +28,7 @@ RDEPEND="
 	ssl? ( >=dev-libs/openssl-1.1 )
 	lua? ( >=dev-lang/lua-5.3 )
 	systemd? ( sys-apps/systemd )
-	dev-libs/libpcre:2"
+	dev-libs/libpcre2"
 
 QA_PRESTRIPPED="
 	usr/bin/mympd


### PR DESCRIPTION
libpcre2 (devel) in gentoo linux:
https://packages.gentoo.org/packages/dev-libs/libpcre2