### PR TITLE
Fix: set crossorigin="use-credentials" for webmanifest

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -20,7 +20,7 @@
 <!--debug-->  <link href="css/theme-light.css" rel="stylesheet"/>
 <!--release   <link href="css/combined.css" rel="stylesheet">-->
   <link href="assets/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon"/>
-  <link href="mympd.webmanifest" rel="manifest" crossorigin="anonymous"/>
+  <link href="mympd.webmanifest" rel="manifest" crossorigin="use-credentials"/>
   <link href="assets/appicon-192.png" rel="apple-touch-icon"/>
   <link href="assets/appicon-192.png" rel="icon"/>
 </head>


### PR DESCRIPTION
Fetching webmanifest when mympd is behind a reverse proxy with HTTP Authentication results in error 401
when browsed from Firefox. Chromium does not seem to have this problem.

According to https://developer.mozilla.org/en-US/docs/web/html/attributes/crossorigin, crossorigin="use-credentials" must be used for webmanifests even when coming from the same origin.
