### PR TITLE
myMPD 9.3.0 depends on liblua5.4; liblua5.3 is not enough.

### DIFF
--- a/contrib/packaging/debian/control
+++ b/contrib/packaging/debian/control
@@ -2,13 +2,13 @@ Source: mympd
 Section: sound
 Priority: optional
 Maintainer: Juergen Mang <mail@jcgames.de>
-Build-Depends: debhelper (>= 10), cmake, perl, libssl-dev, libid3tag0-dev, libflac-dev, liblua5.4-dev, libpcre2-dev
+Build-Depends: debhelper (>= 10), cmake, perl, libssl-dev, libid3tag0-dev, libflac-dev, liblua5.3-dev, libpcre2-dev
 Standards-Version: 4.1.2
 Homepage: https://jcorporation.github.io/myMPD/
 
 Package: mympd
 Architecture: any
-Depends: libc6, openssl, libid3tag0, libflac8, liblua5.4-0, libpcre2-8-0
+Depends: libc6, openssl, libid3tag0, libflac8, liblua5.3-0, libpcre2-8-0
 Description: Standalone and mobile friendly web-based MPD client.
  myMPD is a standalone and lightweight web-based MPD client. It's tuned for
  minimal resource usage and requires only very few dependencies.

--- a/contrib/packaging/debian/control
+++ b/contrib/packaging/debian/control
@@ -2,13 +2,13 @@ Source: mympd
 Section: sound
 Priority: optional
 Maintainer: Juergen Mang <mail@jcgames.de>
-Build-Depends: debhelper (>= 10), cmake, perl, libssl-dev, libid3tag0-dev, libflac-dev, liblua5.4-dev | liblua5.3-dev, libpcre2-dev
+Build-Depends: debhelper (>= 10), cmake, perl, libssl-dev, libid3tag0-dev, libflac-dev, liblua5.4-dev, libpcre2-dev
 Standards-Version: 4.1.2
 Homepage: https://jcorporation.github.io/myMPD/
 
 Package: mympd
 Architecture: any
-Depends: libc6, openssl, libid3tag0, libflac8, liblua5.4-0 | liblua5.3-0, libpcre2-8-0
+Depends: libc6, openssl, libid3tag0, libflac8, liblua5.4-0, libpcre2-8-0
 Description: Standalone and mobile friendly web-based MPD client.
  myMPD is a standalone and lightweight web-based MPD client. It's tuned for
  minimal resource usage and requires only very few dependencies.


### PR DESCRIPTION
Upgrading from myMPD 9.2.4, trying to start the mympd daemon under Debian Bullseye generates the following error:

May 09 19:39:49 nas-skellige systemd[1]: Started myMPD server daemon.
May 09 19:39:50 nas-skellige mympd[2021176]: /usr/bin/mympd: error while loading shared libraries: liblua5.4.so.0: cannot open shared object file: No such file or directory
May 09 19:39:50 nas-skellige systemd[1]: mympd.service: Main process exited, code=exited, status=127/n/a
May 09 19:39:50 nas-skellige systemd[1]: mympd.service: Failed with result 'exit-code'.