### PR TITLE
Add script BatteryIndicator.lua and documentation for it

### DIFF
--- a/docs/additional-topics/battery-indicator.md
+++ b/docs/additional-topics/battery-indicator.md
@@ -1,0 +1,13 @@
+---
+layout: page
+permalink: /additional-topics/battery-indicator
+title: Battery level indicator
+---
+
+The `BatteryIndicator.lua` script replaces the first icon on your homescreen with a battery level indicator that updates itself every time you click it. It makes use of the ligatures myMPD ships with and relies on your operating system reporting the battery level to a text file in /sys.
+
+- Determine where said file is: most likely `/sys/class/power_supply/[…]/capacity`
+- Create a new script and import `BatteryIndicator.lua`
+- Copy and paste the path to your `capacity` file into line 1
+- Make sure the name you gave to your new script is the same as the last attribute in the last line and save
+- Create a timer that runs the script regularly.

--- a/docs/additional-topics/index.md
+++ b/docs/additional-topics/index.md
@@ -9,3 +9,4 @@ title: Additional topics
 - [Recommended MPD configuration]({{ site.baseurl }}/additional-topics/recommended-mpd-configuration)
 - [Scrobble to ListenBrainz]({{ site.baseurl }}/additional-topics/scrobble-to-listenbrainz)
 - [ListenBrainz Feedback]({{ site.baseurl }}/additional-topics/listenbrainz-feedback)
+- [Battery level indicator]({{ site.baseurl }}/additional-topics/battery-indicator)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,5 +54,6 @@ This documentation is for myMPD version {% include version %}.
   - [Recommended MPD configuration]({{ site.baseurl }}/additional-topics/recommended-mpd-configuration)
   - [Scrobble to ListenBrainz]({{ site.baseurl }}/additional-topics/scrobble-to-listenbrainz)
   - [ListenBrainz feedback]({{ site.baseurl }}/additional-topics/listenbrainz-feedback)
+  - [Battery level indicator]({{ site.baseurl }}/additional-topics/battery-indicator)
 - [Known issues]({{ site.baseurl }}/known-issues)
 - [Security]({{ site.baseurl }}/security)

--- a/docs/scripting/scripts/BatteryIndicator.lua
+++ b/docs/scripting/scripts/BatteryIndicator.lua
@@ -1,0 +1,13 @@
+-- {"order":1,"arguments":[]}
+battery = mympd.os_capture("cat /sys/class/power_supply/YourBattery/capacity")
+battery = tonumber(battery)
+
+icon = "battery_full"
+for i = 6, 0, -1 do
+    if battery < math.floor((i * 16.7) + 0.5) then
+        icon = "battery_" .. i .. "_bar"
+    end
+end
+
+battery = battery .. "%"
+rc, raw_result = mympd_api_raw("MYMPD_API_HOME_ICON_SAVE", json.encode({replace = true, oldpos = 0, name = battery, ligature = icon, bgcolor = "#ffffff", color = "#000000", image = "", cmd = "execScriptFromOptions", options = {"BatteryIndicator"}}))

--- a/docs/scripting/scripts/index.json
+++ b/docs/scripting/scripts/index.json
@@ -1,1 +1,1 @@
-{"scripts":["EnableJukebox.lua","ListenBrainz-Feedback.lua","ListenBrainz-Pin.lua","ListenBrainz-Scrobbler.lua","PlayRandomPlaylist.lua"]}
+{"scripts":["EnableJukebox.lua","ListenBrainz-Feedback.lua","ListenBrainz-Pin.lua","ListenBrainz-Scrobbler.lua","PlayRandomPlaylist.lua","BatteryIndicator.lua"]}


### PR DESCRIPTION
You asked me to publish my code for a power indicator, so here it is! It displays the battery level, but can't tell when the device is plugged in. Raspberry Pi's are terribly expensive right now, so I used an old phone that can run postmarketOS instead, and it's not very common for their power supply drivers to be able to do that. I used to use [a crude HTTP server](https://github.com/msoap/shell2http) for this, so this is definitely an improvement.
Hope my code is good.