### PR TITLE
Update ebuild for Gentoo Linux

### DIFF
--- a/contrib/packaging/gentoo/media-sound/mympd/mympd-10.0.1.ebuild
+++ b/contrib/packaging/gentoo/media-sound/mympd/mympd-10.0.1.ebuild
@@ -18,7 +18,8 @@ IUSE="+flac +id3tag +ssl +lua systemd"
 
 BDEPEND="
 	>=dev-util/cmake-3.4
-	dev-lang/perl"
+	dev-lang/perl
+	app-misc/jq"
 
 RDEPEND="
 	acct-group/mympd


### PR DESCRIPTION
For compiling in Gentoo Linux required JSON processor from package app-misc/jq.