### PR TITLE
Fix language name in Japanese

### DIFF
--- a/src/i18n/i18n.txt
+++ b/src/i18n/i18n.txt
@@ -4,7 +4,7 @@ es-VE:Español
 fi-FI:Finnish
 fr-FR:Français
 it-IT:Italiano
-ja-JP:Japanese
+ja-JP:日本語
 ko-KR:한국어
 nl-NL:Nederlands
 zh-CN:简体中文

--- a/src/i18n/json/i18n.json
+++ b/src/i18n/json/i18n.json
@@ -4,7 +4,7 @@
     "en-US": {"desc":"English", "missingPhrases": 0},
     "fr-FR": {"desc":"Français", "missingPhrases": 0},
     "it-IT": {"desc":"Italiano", "missingPhrases": 0},
-    "ja-JP": {"desc":"Japanese", "missingPhrases": 0},
+    "ja-JP": {"desc":"日本語", "missingPhrases": 0},
     "ko-KR": {"desc":"한국어", "missingPhrases": 67},
     "nl-NL": {"desc":"Nederlands", "missingPhrases": 0},
     "zh-CN": {"desc":"简体中文", "missingPhrases": 0}


### PR DESCRIPTION
Hi! First of all, thank you for your such an amazing job on myMPD!
I made the first translations for Japanese through POEditor, but it appears like the language name isn't translated into the target language while others are, so this PR simply replaces "Japanese" with "日本語" (The language name in Japanese).