### PR TITLE
Fix: docs: fix ipv6 default value

### DIFF
--- a/docs/installation/compiling.md
+++ b/docs/installation/compiling.md
@@ -69,7 +69,7 @@ Compile time options are set through environment variables.
 | ----------- | ------- | ----------- |
 | EMBEDDED_ASSETS | - | ON = Embeds assets in binary, default ON for release, else OFF |
 | ENABLE_FLAC | ON | ON = Enables flac usage for extracting coverimages |
-| ENABLE_IPV6 | OFF | ON = Enables IPv6 |
+| ENABLE_IPV6 | ON | ON = Enables IPv6 |
 | ENABLE_LIBASAN | - | ON = compile with libasan, default ON for memcheck, else OFF |
 | ENABLE_LIBID3TAG | ON | ON = Enables libid3tag usage for extracting coverimages |
 | ENABLE_LUA | ON | ON = Enables scripting support with lua |


### PR DESCRIPTION
missed in dbb0ebd8e58e8cc8c78bb847cd63d1e326c40747