### PR TITLE
#947 Fix the Debian installation procedure

### DIFF
--- a/docs/installation/prebuild-packages-debian.md
+++ b/docs/installation/prebuild-packages-debian.md
@@ -14,6 +14,9 @@ curl http://download.opensuse.org/repositories/home:/jcorporation/Debian_11/Rele
 # ⚠️ VERIFY the fingerprint of the downloaded key (A37A ADC4 0A1C C6BE FB75  372F AA09 B8CC E895 BD7D - home:jcorporation OBS Project <home:jcorporation@build.opensuse.org>) 
 gpg --no-default-keyring --keyring /usr/share/keyrings/jcorporation.github.io.gpg --fingerprint
 
+# Make the imported keyring world-readable
+chmod 644 /usr/share/keyrings/jcorporation.github.io.gpg
+
 # Get Debian VERSION_ID from os-release file
 source /etc/os-release
 echo $VERSION_ID


### PR DESCRIPTION
Without the chmod operation to make the key-file world-readable, the described procedure fails with the following error message: 
```
Err:5 http://download.opensuse.org/repositories/home:/jcorporation/Debian_11 ./ InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY AA09B8CCE895BD7D
Fetched 44.9 kB in 2s (18.5 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://download.opensuse.org/repositories/home:/jcorporation/Debian_11 ./ InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY AA09B8CCE895BD7D W: Failed to fetch http://download.opensuse.org/repositories/home:/jcorporation/Debian_11/./InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY AA09B8CCE895BD7D W: Some index files failed to download. They have been ignored, or old ones used instead. 
```