### PR TITLE
Fix: handle Enter key in keydown to ignore IME Enter

### DIFF
--- a/htdocs/js/BrowseDatabase.js
+++ b/htdocs/js/BrowseDatabase.js
@@ -179,31 +179,35 @@ function initBrowseDatabase() {
         }
     }, false);
 
-    document.getElementById('searchDatabaseAlbumListStr').addEventListener('keyup', function(event) {
-        if (ignoreKeys(event) === true) {
+    document.getElementById('searchDatabaseAlbumListStr').addEventListener('keydown', function(event) {
+        if (event.key !== 'Enter') {
             return;
         }
         clearSearchTimer();
         const value = this.value;
-        if (event.key === 'Enter') {
-            if (value !== '') {
-                const op = getSelectValueId('searchDatabaseAlbumListMatch');
-                const crumbEl = document.getElementById('searchDatabaseAlbumListCrumb');
-                crumbEl.appendChild(createSearchCrumb(app.current.filter, op, value));
-                elShow(crumbEl);
-                this.value = '';
-            }
-            else {
-                searchTimer = setTimeout(function() {
-                    searchDatabaseAlbumList(value);
-                }, searchTimerTimeout);
-            }
+        if (value !== '') {
+            const op = getSelectValueId('searchDatabaseAlbumListMatch');
+            const crumbEl = document.getElementById('searchDatabaseAlbumListCrumb');
+            crumbEl.appendChild(createSearchCrumb(app.current.filter, op, value));
+            elShow(crumbEl);
+            this.value = '';
         }
         else {
             searchTimer = setTimeout(function() {
                 searchDatabaseAlbumList(value);
             }, searchTimerTimeout);
         }
+    }, false);
+
+    document.getElementById('searchDatabaseAlbumListStr').addEventListener('keyup', function(event) {
+        if (ignoreKeys(event) === true) {
+            return;
+        }
+        clearSearchTimer();
+        const value = this.value;
+        searchTimer = setTimeout(function() {
+            searchDatabaseAlbumList(value);
+        }, searchTimerTimeout);
     }, false);
 
     document.getElementById('searchDatabaseAlbumListMatch').addEventListener('change', function() {

--- a/htdocs/js/Search.js
+++ b/htdocs/js/Search.js
@@ -83,30 +83,35 @@ function initSearch() {
         }
     }, false);
 
+    document.getElementById('searchStr').addEventListener('keydown', function(event) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+        clearSearchTimer();
+        const value = this.value;
+        if (value !== '') {
+            const op = getSelectValueId('searchMatch');
+            const crumbEl = document.getElementById('searchCrumb');
+            crumbEl.appendChild(createSearchCrumb(app.current.filter, op, value));
+            elShow(crumbEl);
+            this.value = '';
+        }
+        else {
+            searchTimer = setTimeout(function() {
+                doSearch(value);
+            }, searchTimerTimeout);
+        }
+    }, false);
+
     document.getElementById('searchStr').addEventListener('keyup', function(event) {
         if (ignoreKeys(event) === true) {
             return;
         }
         clearSearchTimer();
         const value = this.value;
-        if (event.key === 'Enter') {
-            if (value !== '') {
-                const op = getSelectValueId('searchMatch');
-                document.getElementById('searchCrumb').appendChild(createSearchCrumb(app.current.filter, op, value));
-                elShowId('searchCrumb');
-                this.value = '';
-            }
-            else {
-                searchTimer = setTimeout(function() {
-                    doSearch(value);
-                }, searchTimerTimeout);
-            }
-        }
-        else {
-             searchTimer = setTimeout(function() {
-                 doSearch(value);
-             }, searchTimerTimeout);
-         }
+        searchTimer = setTimeout(function() {
+            doSearch(value);
+        }, searchTimerTimeout);
     }, false);
 
     document.getElementById('searchCrumb').addEventListener('click', function(event) {

--- a/htdocs/js/utility.js
+++ b/htdocs/js/utility.js
@@ -20,6 +20,7 @@ function ignoreKeys(event) {
             event.target.blur();
             return true;
         case 'Enter':
+            return true;
         case 'Backspace':
         case 'Delete':
             // do not ignore some special keys


### PR DESCRIPTION
This PR fixes #977.

During IME compositions, the Enter key event in `keydown` has a different `event.key` property value (`"Process"` or `"Unidentified"` depending on the browser) unlike in `keyup` which is `"Enter"`, and that caused myMPD to trigger the search crumb addition because the Enter key is handled in the `keyup` event.

There is no way to tell apart if the Enter key pressed is a IME Enter or a normal Enter in the `keyup` event, but we can do so in the `keydown`.

With this fix, the `keyup` event now completely ignores the Enter key. Instead, the Enter key is now handled in the `keydown` event so that myMPD only triggers the search crumb addition after the IME composition is ended.

I avoided the use of `event.isComposing` or the composition events like `compositionstart` and `compositionend` as it would be hard to maintain the same behavior if they are not familiar with the concept of IME composition. If we need to change the code for some reason, we just now need to make sure that the Enter key is handled in `keydown` so we can tell apart if that is a normal Enter or not.