### PR TITLE
Fix: restore functionality of Gentoo ebuild

### DIFF
--- a/contrib/packaging/gentoo/media-sound/mympd/mympd-11.0.1.ebuild
+++ b/contrib/packaging/gentoo/media-sound/mympd/mympd-11.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/jcorporation/${MY_PN}/archive/v${PV}.tar.gz -> ${PN}
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~arm ~arm64"
-IUSE="+flac +id3tag +ssl +lua systemd"
+IUSE="+flac +id3tag +lua systemd"
 
 BDEPEND="
     >=dev-util/cmake-3.13
@@ -26,7 +26,7 @@ RDEPEND="
     acct-user/mympd
     id3tag? ( media-libs/libid3tag )
     flac? ( media-libs/flac )
-    ssl ( >=dev-libs/openssl-1.1 )
+    >=dev-libs/openssl-1.1
     lua? ( >=dev-lang/lua-5.3 )
     systemd? ( sys-apps/systemd )
     dev-libs/libpcre2"


### PR DESCRIPTION
The ebuild file was broken in bd12be488220711d0e648a8d9f8e18f3ecf82c22