### PR TITLE
An initial support for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ configure_file(cmake/CopyConfig.cmake.in cmake/CopyConfig.cmake @ONLY)
 configure_file(contrib/initscripts/mympd.service.in contrib/initscripts/mympd.service @ONLY)
 configure_file(contrib/initscripts/mympd.sysVinit.in contrib/initscripts/mympd.sysVinit @ONLY)
 configure_file(contrib/initscripts/mympd.openrc.in contrib/initscripts/mympd.openrc @ONLY)
+configure_file(contrib/initscripts/mympd.freebsdrc.in contrib/initscripts/mympd.freebsdrc @ONLY)
 
 if(CMAKE_BUILD_TYPE MATCHES "(Release|Debug)")
   # set strict global compile flags

--- a/build.sh
+++ b/build.sh
@@ -1077,7 +1077,8 @@ createi18n() {
   fi
   #json to js
   printf "const i18n = " > "$MYMPD_BUILDDIR/htdocs/js/i18n.js"
-  head -c -1 "src/i18n/json/i18n.json" >> "$MYMPD_BUILDDIR/htdocs/js/i18n.js"
+  BYTES=$((`wc -c <src/i18n/json/i18n.json`-1))
+  head -c $BYTES "src/i18n/json/i18n.json" >> "$MYMPD_BUILDDIR/htdocs/js/i18n.js"
   echo ";" >> "$MYMPD_BUILDDIR/htdocs/js/i18n.js"
   #Update serviceworker
   TO_CACHE=""

--- a/cmake/CopyConfig.cmake.in
+++ b/cmake/CopyConfig.cmake.in
@@ -23,6 +23,13 @@ if("@MYMPD_STARTUP_SCRIPT@" STREQUAL "ON")
     file(INSTALL "@CMAKE_CURRENT_BINARY_DIR@/contrib/initscripts/mympd"
         DESTINATION "/etc/init.d"
         FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  elseif(EXISTS "/bin/freebsd-version")
+    #Install FreeBSD rc script
+    file(RENAME "@CMAKE_CURRENT_BINARY_DIR@/contrib/initscripts/mympd.freebsdrc"
+                "@CMAKE_CURRENT_BINARY_DIR@/contrib/initscripts/mympd")
+    file(INSTALL "@CMAKE_CURRENT_BINARY_DIR@/contrib/initscripts/mympd"
+        DESTINATION "/usr/local/etc/rc.d"
+        FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
   else()
     message("No supported init system found, no startup script was installed")
   endif()

--- a/contrib/initscripts/mympd.freebsdrc.in
+++ b/contrib/initscripts/mympd.freebsdrc.in
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# PROVIDE: mympd
+# REQUIRE: DAEMON NETWORKING
+# KEYWORD: shutdown
+#
+# mympd_enable (bool):	Set to "YES" to enable myMPD.
+#			(default: "NO")
+# mympd_realuser (str):	The user that the myMPD will run with.
+#			(defualt: "mympd")
+# mympd_workdir (str):	The directory where the myMPD will store its files.
+#			(defualt: "/var/lib/mympd")
+# mympd_cachedir (str):	The directory that the myMPD will use as a cache.
+#			(default: "/var/cache/mympd")
+
+. /etc/rc.subr
+
+name=mympd
+rcvar=mympd_enable
+desc="myMPD web client for Music Player Daemon"
+
+load_rc_config $name
+
+: ${mympd_enable:="NO"}
+: ${mympd_realuser:="mympd"}
+: ${mympd_workdir:="/var/lib/mympd"}
+: ${mympd_cachedir:="/var/cache/mympd"}
+
+logfile="/var/log/${name}.log"
+pidfile="/var/run/${name}.pid"
+procfile="/usr/local/bin/${name}"
+procflags="-u ${mympd_realuser} -w ${mympd_workdir} -a ${mympd_cachedir}"
+
+command=/usr/sbin/daemon
+command_args="-fr -P ${pidfile} -o ${logfile} ${procfile} ${procflags}"
+
+run_rc_command $1

--- a/contrib/packaging/freebsd/multimedia/mympd/Makefile
+++ b/contrib/packaging/freebsd/multimedia/mympd/Makefile
@@ -1,0 +1,23 @@
+PORTNAME=	myMPD
+DISTVERSIONPREFIX= v
+DISTVERSION=	12.0.2
+CATEGORIES=	multimedia
+
+MAINTAINER=	robert.david@posteo.net
+COMMENT= 	Standalone and mobile friendly web-based MPD client
+WWW=		https://github.com/jcorporation/myMPD
+
+LICENSE=	GPLv3+
+
+BUILD_DEPENDS=	jq:textproc/jq
+LIB_DEPENDS=	libpcre2-8.so:devel/pcre2 \
+		libid3tag.so:audio/libid3tag \
+		libFLAC.so:audio/flac \
+		libogg.so:audio/libogg
+
+USES=		cmake:noninja perl5
+USE_PERL5=	build
+USE_GITHUB=	yes
+GH_ACCOUNT=	jcorporation
+
+.include <bsd.port.mk>

--- a/contrib/packaging/freebsd/multimedia/mympd/pkg-descr
+++ b/contrib/packaging/freebsd/multimedia/mympd/pkg-descr
@@ -1,0 +1,3 @@
+myMPD is a standalone and lightweight web-based MPD client written in C.
+It's tuned for minimal resource usage and requires only very few dependencies.
+Therefore myMPD is ideal for raspberry pis and similar devices.

--- a/contrib/packaging/freebsd/multimedia/mympd/pkg-plist
+++ b/contrib/packaging/freebsd/multimedia/mympd/pkg-plist
@@ -1,0 +1,3 @@
+bin/mympd
+etc/rc.d/mympd
+share/man/man1/mympd.1.gz

--- a/src/lib/cert.c
+++ b/src/lib/cert.c
@@ -26,6 +26,9 @@
 #include <openssl/x509v3.h>
 #include <string.h>
 #include <unistd.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#endif /*__FreeBSD__*/
 
 //private definitions
 static bool certificates_create(sds dir, sds custom_san);

--- a/src/lib/utility.c
+++ b/src/lib/utility.c
@@ -16,6 +16,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif /*__FreeBSD__*/
 
 /**
  * Private definitions

--- a/src/mpd_client/idle.c
+++ b/src/mpd_client/idle.c
@@ -489,7 +489,14 @@ static bool update_mympd_caches(struct t_mympd_state *mympd_state, time_t timeou
         MYMPD_LOG_DEBUG(NULL, "Caches are disabled");
         return true;
     }
+#if defined __FreeBSD__ && __FreeBSD__ < 14
+    (void)timeout;
+    struct t_work_request *request = create_request(-1, 0, MYMPD_API_CACHES_CREATE, NULL, MPD_PARTITION_DEFAULT);
+    request->data = sdscat(request->data, "\"force\":false}}"); //only update if database has changed
+    return mympd_queue_push(mympd_api_queue, request, 0);
+#else
     MYMPD_LOG_DEBUG(NULL, "Adding timer to update the caches");
     return mympd_api_timer_replace(&mympd_state->timer_list, timeout, TIMER_ONE_SHOT_REMOVE,
             timer_handler_by_id, TIMER_ID_CACHES_CREATE, NULL);
+#endif /*__FreeBSD__*/
 }

--- a/src/mpd_worker/mpd_worker.c
+++ b/src/mpd_worker/mpd_worker.c
@@ -16,7 +16,9 @@
 #include "src/mpd_worker/api.h"
 
 #include <pthread.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif /*__linux__*/
 
 /**
  * Private definitions
@@ -96,7 +98,9 @@ bool mpd_worker_start(struct t_mympd_state *mympd_state, struct t_work_request *
  */
 static void *mpd_worker_run(void *arg) {
     thread_logname = sds_replace(thread_logname, "mpdworker");
+#ifdef __linux__
     prctl(PR_SET_NAME, thread_logname, 0, 0, 0);
+#endif /*__linux__*/
     struct t_mpd_worker_state *mpd_worker_state = (struct t_mpd_worker_state *) arg;
 
     if (mpd_client_connect(mpd_worker_state->partition_state, false) == true) {

--- a/src/mympd_api/mympd_api.c
+++ b/src/mympd_api/mympd_api.c
@@ -24,7 +24,9 @@
 #include "src/mympd_api/timer_handlers.h"
 #include "src/mympd_api/trigger.h"
 
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif /*__linux__*/
 
 /**
  * This is the main function for the mympd_api thread
@@ -32,7 +34,9 @@
  */
 void *mympd_api_loop(void *arg_config) {
     thread_logname = sds_replace(thread_logname, "mympdapi");
+#ifdef __linux__
     prctl(PR_SET_NAME, thread_logname, 0, 0, 0);
+#endif /*__linux__*/
 
     //create initial mympd_state struct and set defaults
     struct t_mympd_state *mympd_state = malloc_assert(sizeof(struct t_mympd_state));

--- a/src/mympd_api/scripts.c
+++ b/src/mympd_api/scripts.c
@@ -22,7 +22,9 @@
 #include <errno.h>
 #include <pthread.h>
 #include <string.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif /*__linux__*/
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -462,7 +464,9 @@ static sds script_get_result(lua_State *lua_vm, int rc) {
  */
 static void *script_execute(void *script_thread_arg) {
     thread_logname = sds_replace(thread_logname, "script");
+#ifdef __linux__
     prctl(PR_SET_NAME, thread_logname, 0, 0, 0);
+#endif /*__linux__*/
     struct t_script_thread_arg *script_arg = (struct t_script_thread_arg *) script_thread_arg;
 
     int rc = 0;

--- a/src/mympd_api/timer.c
+++ b/src/mympd_api/timer.c
@@ -19,8 +19,15 @@
 #include <poll.h>
 #include <stdbool.h>
 #include <string.h>
-#include <sys/timerfd.h>
 #include <unistd.h>
+
+/* timerfd is not supported on FreeBSD < 14, so the timers doesn't work */
+#if defined __FreeBSD__ && __FreeBSD__ < 14
+#define timerfd_create(a, b) -1
+#define timerfd_settime(a, b, c, d) (void)0
+#else
+#include <sys/timerfd.h>
+#endif
 
 /**
  * Private definitions

--- a/src/web_server/web_server.c
+++ b/src/web_server/web_server.c
@@ -22,7 +22,9 @@
 
 #include <inttypes.h>
 #include <libgen.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif /*__linux__*/
 
 /**
  * Private definitions
@@ -137,7 +139,9 @@ void *web_server_free(struct mg_mgr *mgr) {
  */
 void *web_server_loop(void *arg_mgr) {
     thread_logname = sds_replace(thread_logname, "webserver");
+#ifdef __linux__
     prctl(PR_SET_NAME, thread_logname, 0, 0, 0);
+#endif /*__linux__*/
     struct mg_mgr *mgr = (struct mg_mgr *) arg_mgr;
     struct t_mg_user_data *mg_user_data = (struct t_mg_user_data *) mgr->userdata;
 


### PR DESCRIPTION
This is an initial support for the FreeBSD.

The source can be built on FreeBSD and Linux. Tested both debug and release build.

On FreeBSD it is working with some exceptions.
1) I have skipped the lua support for now. So it can be built only without it. I will add it as next PR, it was not a priority.
2) The timers are not supported for now, since the missing timerfd(2) syscall in FreeBSD <=13. It was added in the FreeBSD 14, which isn't released yet.

I understand if the timerfd patch would not be accepted, it is little bit a nasty hack. I may add it as patch to the ports tree when I will submit the myMPD port. I may also implement this patch somehow else, but since it is only a temporary fix, I haven't seen a point in much more complex fixing.

I will not submit the port tree Makefile in this repo, I don't see a point in it. But if you want to have it here as a reference, I will add it. I have also created a rc.d script, which is not fully tuned yet. I may submit it also if you want, otherwise it will be submitted in the FreeBSD's port tree.