### PR TITLE
src/lib/thread.c: fix compilation error on FreeBSD

### DIFF
--- a/src/lib/thread.c
+++ b/src/lib/thread.c
@@ -23,12 +23,14 @@ void set_threadname(const char *threadname) {
 
 #else
 
+#include <string.h>
+
 /**
  * Ignore the thread name setting
  * @param threadname name of thread
  */
-void set_threadname(const char *threadname) {
-    MYMPD_LOG_DEBUG("Setting the thread name is not supported");
+void set_threadname(__attribute__((__unused__)) const char *threadname) {
+    MYMPD_LOG_DEBUG(NULL, "Setting the thread name is not supported");
 }
 
 #endif


### PR DESCRIPTION
There is a compilation error on FreeeBSD. Sorry I haven't spotted that earlier (I forgot my own patches for threadname in the build tree). 

With this patch the myMPD 13.0.0 now compile and works ok.

The `__unused__` is GCC and Clang specific, but I do not expect myMPD would be supported on something else than Clang and GCC anyway. But without it, the default FreeBSD build system will fail.

The `string.h` is needed here because of the NULL, FreeBSD's (and MacOS also I think) Clang does not define it by default. More precisely it is defined in `sys/_null.h`, but using `string.h` or `stdlib.h` is a more convenient way.