### PR TITLE
src/lib/thread.c: fix compilation error on FreeBSD

### DIFF
--- a/src/lib/thread.c
+++ b/src/lib/thread.c
@@ -23,13 +23,15 @@ void set_threadname(const char *threadname) {
 
 #else
 
+#include <string.h>
+
 /**
  * Ignore the thread name setting
  * @param threadname name of thread
  */
 void set_threadname(const char *threadname) {
     (void) threadname;
-    MYMPD_LOG_DEBUG("Setting the thread name is not supported");
+    MYMPD_LOG_DEBUG(NULL, "Setting the thread name is not supported");
 }
 
 #endif


### PR DESCRIPTION
The previous PR was not only the unused threadname. Also the LOG message fails to compile (wrong prototype).