### PR TITLE
Avoid detecting Chrome based browsers as Safari

### DIFF
--- a/htdocs/js/globales.js
+++ b/htdocs/js/globales.js
@@ -1119,7 +1119,7 @@ function setUserAgentData() {
                 ? false
                 : /iPhone|iPad|iPod|Android|Mobile/i.test(navigator.userAgent);
         /** @type {boolean} */
-        userAgentData.isSafari = /Safari/i.test(navigator.userAgent);
+        userAgentData.isSafari = /Safari/i.test(navigator.userAgent) && ! /Chrome/i.test(navigator.userAgent);
     }
 }
 setUserAgentData();


### PR DESCRIPTION
## Issue

The playing progress on the current track in the playlist view wouldn't be shown on my Chromium desktop browser or my Chrome Android browser. After debugging it, the problem was that it was detected as Safari by myMPD, and that feature was disabled.

## Fix

According to [this](https://www.whatismybrowser.com/guides/the-latest-user-agent/), it seems that all Chrome based browsers include the "Safari" string in the user agent, so that check is not enough to detect Safari browsers. The simplest way to detect an actual Safari browser is that it includes the "Safari" string but not the "Chrome" string.

There are probably better ways to detect the browser (and probably many libraries out there to do it), but this seems like an easy fix for the current set of browsers.