### PR TITLE
fix: MusicBrainz Work Link

### DIFF
--- a/htdocs/js/tags.js
+++ b/htdocs/js/tags.js
@@ -467,6 +467,9 @@ function getMBtagLink(tag, value) {
         case 'MUSICBRAINZ_TRACKID':
             MBentity = 'recording';
             break;
+        case 'MUSICBRAINZ_WORKID':
+            MBentity = 'work';
+            break;
         case 'MUSICBRAINZ_RELEASEGROUPID':
             MBentity = 'release-group';
             break;


### PR DESCRIPTION
* The MusicBrainz Work ID link wasn't being generated.

Here's what it looks like after the small fix. 
![image](https://github.com/user-attachments/assets/3761ca79-f7dd-481a-9104-6e22b178d942)
