### PR TITLE
Fix: handle script names with spaces

### DIFF
--- a/htdocs/js/viewHome.js
+++ b/htdocs/js/viewHome.js
@@ -129,7 +129,7 @@ function updateHomeWidget(card) {
     for (const key in data.arguments) {
         query.push(myEncodeURIComponent(key) + '=' + myEncodeURIComponent(data.arguments[key]));
     }
-    httpGet(getMyMPDuri('http') + '/script/' +  localSettings.partition + '/' + data.script + '?' + query.join('&'),
+    httpGet(getMyMPDuri('http') + '/script/' +  localSettings.partition + '/' + myEncodeURIComponent(data.script) + '?' + query.join('&'),
         function(response) {
             setTimeout(function() {
                 card.querySelector('.card-title a').textContent = 'refresh';

--- a/src/web_server/scripts.c
+++ b/src/web_server/scripts.c
@@ -37,7 +37,8 @@ bool script_execute_http(struct mg_connection *nc, struct mg_http_message *hm, s
     sds script = sdsdup(partition);
     partition = sds_dirname(partition);
     partition = sds_basename(partition);
-    script = sds_basename(script);
+    sds script_encoded = sds_basename(script);
+    script = sds_urldecode(sdsempty(), script_encoded, strlen(script_encoded), false);
     if (vcb_isfilepath(script) == false) {
         FREE_SDS(script);
         FREE_SDS(partition);
@@ -76,5 +77,6 @@ bool script_execute_http(struct mg_connection *nc, struct mg_http_message *hm, s
     request->extra = extra;
     FREE_SDS(partition);
     FREE_SDS(script);
+    FREE_SDS(script_encoded);
     return push_request(request, 0);
 }


### PR DESCRIPTION
Creating a script with spaces in the name causes the script to fail to execute when used in an home screen widget
